### PR TITLE
Implement websockets to pass keypoints from client to backend

### DIFF
--- a/src/components/WebSocketTestComponent.tsx
+++ b/src/components/WebSocketTestComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useWebSocketContext } from '../contexts/websocketContext';
 import { WebSocketConnectionState } from '../types/websocket';
 
@@ -28,7 +28,7 @@ export default function WebSocketTestComponent() {
   const [wsUrl, setWsUrl] = useState('ws://localhost:8000/ws/video_stream');
 
   // Track messages for display
-  React.useEffect(() => {
+  useEffect(() => {
     if (lastMessage) {
       const newMessage: TestMessage = {
         id: Date.now().toString(),
@@ -37,7 +37,7 @@ export default function WebSocketTestComponent() {
         timestamp: new Date(),
         direction: 'incoming'
       };
-      setMessages(prev => [newMessage, ...prev.slice(0, 9)]); // Keep last 10 messages
+      setMessages(prev => [...prev, newMessage].slice(-10)); // Keep last 10 messages
     }
   }, [lastMessage]);
 
@@ -64,7 +64,7 @@ export default function WebSocketTestComponent() {
       timestamp: new Date(),
       direction: 'outgoing'
     };
-    setMessages(prev => [displayMessage, ...prev.slice(0, 9)]);
+    setMessages(prev => [...prev, displayMessage].slice(-10));
   };
 
   const handleSendTestFrame = () => {
@@ -88,7 +88,7 @@ export default function WebSocketTestComponent() {
       timestamp: new Date(),
       direction: 'outgoing'
     };
-    setMessages(prev => [displayMessage, ...prev.slice(0, 9)]);
+    setMessages(prev => [...prev, displayMessage].slice(-10));
   };
 
   const getConnectionStatusColor = () => {
@@ -272,11 +272,11 @@ export default function WebSocketTestComponent() {
             </button>
           </div>
           
-          <div className="space-y-2 max-h-64 overflow-y-auto">
+          <div className="space-y-2">
             {messages.length === 0 ? (
               <p className="text-gray-500 text-sm">No messages yet. Connect and interact to see message history.</p>
             ) : (
-              messages.map((message) => (
+              messages.slice().reverse().map((message) => (
                 <div
                   key={message.id}
                   className={`p-3 rounded-md text-sm ${

--- a/src/components/WebSocketTestComponent.tsx
+++ b/src/components/WebSocketTestComponent.tsx
@@ -1,0 +1,309 @@
+import React, { useState } from 'react';
+import { useWebSocketContext } from '../contexts/websocketContext';
+import { WebSocketConnectionState } from '../types/websocket';
+
+interface TestMessage {
+  id: string;
+  type: string;
+  data: any;
+  timestamp: Date;
+  direction: 'incoming' | 'outgoing';
+}
+
+export default function WebSocketTestComponent() {
+  const {
+    connectionState,
+    lastMessage,
+    lastKeypointsData,
+    lastError,
+    sendMessage,
+    sendFrame,
+    connect,
+    disconnect,
+    isConnected
+  } = useWebSocketContext();
+
+  const [messages, setMessages] = useState<TestMessage[]>([]);
+  const [testFrame, setTestFrame] = useState<string>('');
+  const [wsUrl, setWsUrl] = useState('ws://localhost:8000/ws/video_stream');
+
+  // Track messages for display
+  React.useEffect(() => {
+    if (lastMessage) {
+      const newMessage: TestMessage = {
+        id: Date.now().toString(),
+        type: lastMessage.type,
+        data: lastMessage,
+        timestamp: new Date(),
+        direction: 'incoming'
+      };
+      setMessages(prev => [newMessage, ...prev.slice(0, 9)]); // Keep last 10 messages
+    }
+  }, [lastMessage]);
+
+  const handleConnect = () => {
+    connect();
+  };
+
+  const handleDisconnect = () => {
+    disconnect();
+  };
+
+  const handleSendPing = () => {
+    const pingMessage = {
+      type: 'ping' as const,
+      timestamp: Date.now() / 1000,
+    };
+    sendMessage(pingMessage);
+    
+    // Add to message display
+    const displayMessage: TestMessage = {
+      id: Date.now().toString(),
+      type: 'ping',
+      data: pingMessage,
+      timestamp: new Date(),
+      direction: 'outgoing'
+    };
+    setMessages(prev => [displayMessage, ...prev.slice(0, 9)]);
+  };
+
+  const handleSendTestFrame = () => {
+    if (!testFrame.trim()) {
+      alert('Please enter test frame data');
+      return;
+    }
+    
+    // Create a simple base64 test image or use the provided test data
+    const frameData = testFrame.startsWith('data:image/') ? 
+      testFrame.split(',')[1] : // Extract base64 part if it's a data URL
+      testFrame;
+    
+    sendFrame(frameData);
+    
+    // Add to message display
+    const displayMessage: TestMessage = {
+      id: Date.now().toString(),
+      type: 'frame',
+      data: { type: 'frame', frame: frameData.substring(0, 50) + '...' },
+      timestamp: new Date(),
+      direction: 'outgoing'
+    };
+    setMessages(prev => [displayMessage, ...prev.slice(0, 9)]);
+  };
+
+  const getConnectionStatusColor = () => {
+    switch (connectionState) {
+      case WebSocketConnectionState.CONNECTED:
+        return 'bg-green-100 text-green-800 border-green-200';
+      case WebSocketConnectionState.CONNECTING:
+        return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+      case WebSocketConnectionState.ERROR:
+        return 'bg-red-100 text-red-800 border-red-200';
+      default:
+        return 'bg-gray-100 text-gray-800 border-gray-200';
+    }
+  };
+
+  const clearMessages = () => {
+    setMessages([]);
+  };
+
+  const generateTestImage = () => {
+    // Create a simple test image data URL (1x1 pixel red image)
+    const canvas = document.createElement('canvas');
+    canvas.width = 100;
+    canvas.height = 100;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      ctx.fillStyle = '#FF0000';
+      ctx.fillRect(0, 0, 100, 100);
+      ctx.fillStyle = '#FFFFFF';
+      ctx.font = '12px Arial';
+      ctx.fillText('TEST', 35, 55);
+    }
+    const dataUrl = canvas.toDataURL('image/jpeg', 0.8);
+    setTestFrame(dataUrl);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <div className="bg-white rounded-lg shadow-lg p-6">
+        <h2 className="text-2xl font-bold text-gray-900 mb-4">WebSocket Connection Test</h2>
+        
+        {/* Connection Status */}
+        <div className="mb-6">
+          <div className={`inline-flex items-center px-4 py-2 rounded-lg border ${getConnectionStatusColor()}`}>
+            <div className={`w-3 h-3 rounded-full mr-2 ${
+              isConnected ? 'bg-green-500' : 
+              connectionState === WebSocketConnectionState.CONNECTING ? 'bg-yellow-500' :
+              connectionState === WebSocketConnectionState.ERROR ? 'bg-red-500' : 'bg-gray-500'
+            }`}></div>
+            <span className="font-medium">Status: {connectionState}</span>
+          </div>
+        </div>
+
+        {/* Connection Controls */}
+        <div className="mb-6 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              WebSocket URL:
+            </label>
+            <input
+              type="text"
+              value={wsUrl}
+              onChange={(e) => setWsUrl(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="ws://localhost:8000/ws/video_stream"
+            />
+          </div>
+          
+          <div className="flex space-x-3">
+            <button
+              onClick={handleConnect}
+              disabled={isConnected}
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              Connect
+            </button>
+            <button
+              onClick={handleDisconnect}
+              disabled={!isConnected}
+              className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              Disconnect
+            </button>
+            <button
+              onClick={handleSendPing}
+              disabled={!isConnected}
+              className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              Send Ping
+            </button>
+          </div>
+        </div>
+
+        {/* Frame Testing */}
+        <div className="mb-6 space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900">Frame Testing</h3>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Test Frame Data (Base64 or Data URL):
+            </label>
+            <div className="flex space-x-2">
+              <textarea
+                value={testFrame}
+                onChange={(e) => setTestFrame(e.target.value)}
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                rows={3}
+                placeholder="Paste base64 image data or data URL here..."
+              />
+              <div className="flex flex-col space-y-2">
+                <button
+                  onClick={generateTestImage}
+                  className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 whitespace-nowrap"
+                >
+                  Generate Test Image
+                </button>
+                <button
+                  onClick={handleSendTestFrame}
+                  disabled={!isConnected || !testFrame.trim()}
+                  className="px-4 py-2 bg-orange-600 text-white rounded-md hover:bg-orange-700 disabled:bg-gray-400 disabled:cursor-not-allowed whitespace-nowrap"
+                >
+                  Send Frame
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Error Display */}
+        {lastError && (
+          <div className="mb-6 p-4 bg-red-100 border border-red-200 rounded-md">
+            <h4 className="text-sm font-medium text-red-800 mb-1">Last Error:</h4>
+            <p className="text-sm text-red-700">{lastError.message}</p>
+            {/* <p className="text-xs text-red-600 mt-1">
+              Timestamp: {lastError.timestamp ? new Date(lastError.timestamp * 1000).toLocaleString() : 'N/A'}
+            </p> */}
+          </div>
+        )}
+
+        {/* Keypoints Data Display */}
+        {lastKeypointsData && (
+          <div className="mb-6 p-4 bg-blue-100 border border-blue-200 rounded-md">
+            <h4 className="text-sm font-medium text-blue-800 mb-2">Latest Keypoints Data:</h4>
+            <div className="text-sm text-blue-700 space-y-1">
+              <p><strong>Success:</strong> {lastKeypointsData.data.success ? 'Yes' : 'No'}</p>
+              {lastKeypointsData.data.frame_info && (
+                <div>
+                  <p><strong>Frame Info:</strong></p>
+                  <ul className="ml-4 space-y-1">
+                    <li>Size: {lastKeypointsData.data.frame_info.width}x{lastKeypointsData.data.frame_info.height}</li>
+                    <li>Has Pose: {lastKeypointsData.data.frame_info.has_pose ? 'Yes' : 'No'}</li>
+                    <li>Has Face: {lastKeypointsData.data.frame_info.has_face ? 'Yes' : 'No'}</li>
+                    <li>Has Left Hand: {lastKeypointsData.data.frame_info.has_left_hand ? 'Yes' : 'No'}</li>
+                    <li>Has Right Hand: {lastKeypointsData.data.frame_info.has_right_hand ? 'Yes' : 'No'}</li>
+                  </ul>
+                </div>
+              )}
+              {lastKeypointsData.data.keypoints && (
+                <div>
+                  <p><strong>Keypoints:</strong></p>
+                  <ul className="ml-4 space-y-1">
+                    <li>Pose points: {lastKeypointsData.data.keypoints.pose?.length || 0}</li>
+                    <li>Face points: {lastKeypointsData.data.keypoints.face?.length || 0}</li>
+                    <li>Left hand points: {lastKeypointsData.data.keypoints.left_hand?.length || 0}</li>
+                    <li>Right hand points: {lastKeypointsData.data.keypoints.right_hand?.length || 0}</li>
+                  </ul>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Message History */}
+        <div className="space-y-4">
+          <div className="flex justify-between items-center">
+            <h3 className="text-lg font-semibold text-gray-900">Message History</h3>
+            <button
+              onClick={clearMessages}
+              className="px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300"
+            >
+              Clear History
+            </button>
+          </div>
+          
+          <div className="space-y-2 max-h-64 overflow-y-auto">
+            {messages.length === 0 ? (
+              <p className="text-gray-500 text-sm">No messages yet. Connect and interact to see message history.</p>
+            ) : (
+              messages.map((message) => (
+                <div
+                  key={message.id}
+                  className={`p-3 rounded-md text-sm ${
+                    message.direction === 'incoming' 
+                      ? 'bg-blue-50 border-l-4 border-blue-400' 
+                      : 'bg-green-50 border-l-4 border-green-400'
+                  }`}
+                >
+                  <div className="flex justify-between items-start mb-1">
+                    <span className={`font-medium ${
+                      message.direction === 'incoming' ? 'text-blue-800' : 'text-green-800'
+                    }`}>
+                      {message.direction === 'incoming' ? '← Received' : '→ Sent'}: {message.type}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {message.timestamp.toLocaleTimeString()}
+                    </span>
+                  </div>
+                  <pre className="text-xs text-gray-700 whitespace-pre-wrap overflow-x-auto">
+                    {JSON.stringify(message.data, null, 2)}
+                  </pre>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/contexts/websocketContext.tsx
+++ b/src/contexts/websocketContext.tsx
@@ -6,6 +6,7 @@ import type {
   OutgoingMessage,
   KeypointsMessage,
   ErrorMessage,
+  Keypoints,
 } from "../types/websocket";
 
 interface WebSocketContextType {
@@ -14,7 +15,7 @@ interface WebSocketContextType {
   lastKeypointsData: KeypointsMessage | null;
   lastError: ErrorMessage | null;
   sendMessage: (message: OutgoingMessage) => void;
-  sendFrame: (frameData: string) => void;
+  sendKeypoints: (keypoints: Keypoints, sequenceId?: string) => void;
   connect: () => void;
   disconnect: () => void;
   isConnected: boolean;

--- a/src/contexts/websocketContext.tsx
+++ b/src/contexts/websocketContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { useWebSocket } from "../hooks/useWebSocket";
+import { WebSocketConnectionState } from "../types/websocket";
+import type {
+  IncomingMessage,
+  OutgoingMessage,
+  KeypointsMessage,
+  ErrorMessage,
+} from "../types/websocket";
+
+interface WebSocketContextType {
+  connectionState: WebSocketConnectionState;
+  lastMessage: IncomingMessage | null;
+  lastKeypointsData: KeypointsMessage | null;
+  lastError: ErrorMessage | null;
+  sendMessage: (message: OutgoingMessage) => void;
+  sendFrame: (frameData: string) => void;
+  connect: () => void;
+  disconnect: () => void;
+  isConnected: boolean;
+}
+
+const WebSocketContext = createContext<WebSocketContextType | null>(null);
+
+interface WebSocketProviderProps {
+  children: ReactNode;
+  url?: string;
+  autoConnect?: boolean;
+}
+
+export function WebSocketProvider({
+  children,
+  url = "ws://localhost:8000/ws/video_stream",
+  autoConnect = false,
+}: WebSocketProviderProps) {
+  const webSocketData = useWebSocket({
+    url,
+    autoConnect,
+    pingInterval: 30000,
+    reconnectAttempts: 3,
+    reconnectDelay: 1000,
+  });
+
+  return (
+    <WebSocketContext.Provider value={webSocketData}>
+      {children}
+    </WebSocketContext.Provider>
+  );
+}
+
+export function useWebSocketContext(): WebSocketContextType {
+  const context = useContext(WebSocketContext);
+  if (!context) {
+    throw new Error(
+      "useWebSocketContext must be used within a WebSocketProvider"
+    );
+  }
+  return context;
+}

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1,0 +1,228 @@
+// hooks/useWebSocket.ts
+import { useCallback, useEffect, useRef, useState } from "react";
+import { WebSocketConnectionState } from "../types/websocket";
+import type {
+  IncomingMessage,
+  OutgoingMessage,
+  KeypointsMessage,
+  ErrorMessage,
+  PongMessage,
+} from "../types/websocket";
+
+interface UseWebSocketOptions {
+  url: string;
+  autoConnect?: boolean;
+  pingInterval?: number;
+  reconnectAttempts?: number;
+  reconnectDelay?: number;
+}
+
+interface UseWebSocketReturn {
+  connectionState: WebSocketConnectionState;
+  lastMessage: IncomingMessage | null;
+  lastKeypointsData: KeypointsMessage | null;
+  lastError: ErrorMessage | null;
+  sendMessage: (message: OutgoingMessage) => void;
+  sendFrame: (frameData: string) => void;
+  connect: () => void;
+  disconnect: () => void;
+  isConnected: boolean;
+}
+
+export function useWebSocket({
+  url,
+  autoConnect = false,
+  pingInterval = 30000,
+  reconnectAttempts = 3,
+  reconnectDelay = 1000,
+}: UseWebSocketOptions): UseWebSocketReturn {
+  const [connectionState, setConnectionState] =
+    useState<WebSocketConnectionState>(WebSocketConnectionState.DISCONNECTED);
+  const [lastMessage, setLastMessage] = useState<IncomingMessage | null>(null);
+  const [lastKeypointsData, setLastKeypointsData] =
+    useState<KeypointsMessage | null>(null);
+  const [lastError, setLastError] = useState<ErrorMessage | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const pingIntervalRef = useRef<number | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectControllerRef = useRef<AbortController | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (pingIntervalRef.current) {
+      clearInterval(pingIntervalRef.current);
+      pingIntervalRef.current = null;
+    }
+    if (reconnectControllerRef.current) {
+      reconnectControllerRef.current.abort();
+      reconnectControllerRef.current = null;
+    }
+  }, []);
+
+  const startPingInterval = useCallback(() => {
+    cleanup();
+    pingIntervalRef.current = setInterval(() => {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        const pingMessage: OutgoingMessage = {
+          type: "ping",
+          timestamp: Date.now() / 1000,
+        };
+        wsRef.current.send(JSON.stringify(pingMessage));
+      }
+    }, pingInterval);
+  }, [pingInterval, cleanup]);
+
+  const handleMessage = useCallback((event: MessageEvent) => {
+    try {
+      const message: IncomingMessage = JSON.parse(event.data);
+      setLastMessage(message);
+
+      switch (message.type) {
+        case "keypoints":
+          setLastKeypointsData(message as KeypointsMessage);
+          break;
+        case "error":
+          setLastError(message as ErrorMessage);
+          console.error("WebSocket error:", message.message);
+          break;
+        case "pong":
+          // Handle pong response - connection is healthy
+          break;
+        default:
+          console.warn("Unknown message type:", (message as any).type);
+      }
+    } catch (error) {
+      console.error("Failed to parse WebSocket message:", error);
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      return; // Already connected
+    }
+
+    cleanup();
+    setConnectionState(WebSocketConnectionState.CONNECTING);
+
+    try {
+      wsRef.current = new WebSocket(url);
+
+      wsRef.current.onopen = () => {
+        console.log("WebSocket connected");
+        setConnectionState(WebSocketConnectionState.CONNECTED);
+        reconnectAttemptsRef.current = 0;
+        startPingInterval();
+      };
+
+      wsRef.current.onmessage = handleMessage;
+
+      wsRef.current.onclose = (event) => {
+        console.log("WebSocket disconnected:", event.code, event.reason);
+        cleanup();
+        setConnectionState(WebSocketConnectionState.DISCONNECTED);
+
+        // Only attempt reconnect if it wasn't a manual disconnect
+        if (
+          event.code !== 1000 &&
+          reconnectAttemptsRef.current < reconnectAttempts
+        ) {
+          reconnectAttemptsRef.current++;
+          console.log(
+            `Attempting to reconnect... (${reconnectAttemptsRef.current}/${reconnectAttempts})`
+          );
+
+          reconnectControllerRef.current = new AbortController();
+          const delay = reconnectDelay * reconnectAttemptsRef.current;
+
+          setTimeout(() => {
+            if (!reconnectControllerRef.current?.signal.aborted) {
+              connect();
+            }
+          }, delay);
+        } else if (event.code !== 1000) {
+          console.error("Max reconnection attempts reached");
+          setConnectionState(WebSocketConnectionState.ERROR);
+        }
+      };
+
+      wsRef.current.onerror = (error) => {
+        console.error("WebSocket error:", error);
+        setConnectionState(WebSocketConnectionState.ERROR);
+      };
+    } catch (error) {
+      console.error("Failed to create WebSocket connection:", error);
+      setConnectionState(WebSocketConnectionState.ERROR);
+    }
+  }, [
+    url,
+    handleMessage,
+    startPingInterval,
+    cleanup,
+    reconnectAttempts,
+    reconnectDelay,
+  ]);
+
+  const disconnect = useCallback(() => {
+    cleanup();
+    reconnectAttemptsRef.current = reconnectAttempts; // Prevent auto-reconnect
+
+    if (wsRef.current) {
+      wsRef.current.close(1000, "Manual disconnect");
+      wsRef.current = null;
+    }
+    setConnectionState(WebSocketConnectionState.DISCONNECTED);
+  }, [cleanup, reconnectAttempts]);
+
+  const sendMessage = useCallback((message: OutgoingMessage) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      try {
+        const messageWithTimestamp = {
+          ...message,
+          timestamp: message.timestamp || Date.now() / 1000,
+        };
+        wsRef.current.send(JSON.stringify(messageWithTimestamp));
+      } catch (error) {
+        console.error("Failed to send WebSocket message:", error);
+      }
+    } else {
+      console.warn("WebSocket is not connected");
+    }
+  }, []);
+
+  const sendFrame = useCallback(
+    (frameData: string) => {
+      sendMessage({
+        type: "frame",
+        frame: frameData,
+      });
+    },
+    [sendMessage]
+  );
+
+  // Auto-connect on mount if enabled
+  useEffect(() => {
+    if (autoConnect) {
+      connect();
+    }
+
+    // Cleanup on unmount
+    return () => {
+      cleanup();
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, [autoConnect, connect, cleanup]);
+
+  return {
+    connectionState,
+    lastMessage,
+    lastKeypointsData,
+    lastError,
+    sendMessage,
+    sendFrame,
+    connect,
+    disconnect,
+    isConnected: connectionState === WebSocketConnectionState.CONNECTED,
+  };
+}

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -6,7 +6,7 @@ import type {
   OutgoingMessage,
   KeypointsMessage,
   ErrorMessage,
-  PongMessage,
+  Keypoints,
 } from "../types/websocket";
 
 interface UseWebSocketOptions {
@@ -23,7 +23,7 @@ interface UseWebSocketReturn {
   lastKeypointsData: KeypointsMessage | null;
   lastError: ErrorMessage | null;
   sendMessage: (message: OutgoingMessage) => void;
-  sendFrame: (frameData: string) => void;
+  sendKeypoints: (keypoints: Keypoints, sequenceId?: string) => void;
   connect: () => void;
   disconnect: () => void;
   isConnected: boolean;
@@ -189,11 +189,12 @@ export function useWebSocket({
     }
   }, []);
 
-  const sendFrame = useCallback(
-    (frameData: string) => {
+  const sendKeypoints = useCallback(
+    (keypoints: Keypoints, sequenceId?: string) => {
       sendMessage({
-        type: "frame",
-        frame: frameData,
+        type: "keypoint_sequence",
+        keypoints,
+        sequence_id: sequenceId || `seq_${Date.now()}`,
       });
     },
     [sendMessage]
@@ -220,7 +221,7 @@ export function useWebSocket({
     lastKeypointsData,
     lastError,
     sendMessage,
-    sendFrame,
+    sendKeypoints,
     connect,
     disconnect,
     isConnected: connectionState === WebSocketConnectionState.CONNECTED,

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -9,10 +9,17 @@ export interface FrameInfo {
 }
 
 export interface Keypoints {
-  pose: number[][];
-  face: number[][];
-  left_hand: number[][];
-  right_hand: number[][];
+  // 33 pose landmarks: [x, y, z, visibility]
+  pose: [number, number, number, number][];
+
+  // 468 face landmarks: [x, y, z]
+  face: [number, number, number][];
+
+  // 21 left hand landmarks: [x, y, z]
+  left_hand: [number, number, number][];
+
+  // 21 right hand landmarks: [x, y, z]
+  right_hand: [number, number, number][];
 }
 
 export interface ProcessingResult {
@@ -27,9 +34,10 @@ export interface WebSocketMessage {
   timestamp?: number;
 }
 
-export interface FrameMessage extends WebSocketMessage {
-  type: "frame";
-  frame: string; // Base64 encoded image
+export interface KeypointSequenceMessage extends WebSocketMessage {
+  type: "keypoint_sequence";
+  keypoints: Keypoints;
+  sequence_id: string;
 }
 
 export interface PingMessage extends WebSocketMessage {
@@ -51,7 +59,7 @@ export interface ErrorMessage extends WebSocketMessage {
 }
 
 export type IncomingMessage = KeypointsMessage | PongMessage | ErrorMessage;
-export type OutgoingMessage = FrameMessage | PingMessage;
+export type OutgoingMessage = PingMessage | KeypointSequenceMessage;
 
 export const WebSocketConnectionState = {
   CONNECTING: "CONNECTING",

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -1,0 +1,64 @@
+// types/websocket.ts
+export interface FrameInfo {
+  width: number;
+  height: number;
+  has_pose: boolean;
+  has_face: boolean;
+  has_left_hand: boolean;
+  has_right_hand: boolean;
+}
+
+export interface Keypoints {
+  pose: number[][];
+  face: number[][];
+  left_hand: number[][];
+  right_hand: number[][];
+}
+
+export interface ProcessingResult {
+  success: boolean;
+  keypoints: Keypoints;
+  frame_info: FrameInfo;
+  error?: string;
+}
+
+export interface WebSocketMessage {
+  type: string;
+  timestamp?: number;
+}
+
+export interface FrameMessage extends WebSocketMessage {
+  type: "frame";
+  frame: string; // Base64 encoded image
+}
+
+export interface PingMessage extends WebSocketMessage {
+  type: "ping";
+}
+
+export interface KeypointsMessage extends WebSocketMessage {
+  type: "keypoints";
+  data: ProcessingResult;
+}
+
+export interface PongMessage extends WebSocketMessage {
+  type: "pong";
+}
+
+export interface ErrorMessage extends WebSocketMessage {
+  type: "error";
+  message: string;
+}
+
+export type IncomingMessage = KeypointsMessage | PongMessage | ErrorMessage;
+export type OutgoingMessage = FrameMessage | PingMessage;
+
+export const WebSocketConnectionState = {
+  CONNECTING: "CONNECTING",
+  CONNECTED: "CONNECTED",
+  DISCONNECTED: "DISCONNECTED",
+  ERROR: "ERROR",
+} as const;
+
+export type WebSocketConnectionState =
+  (typeof WebSocketConnectionState)[keyof typeof WebSocketConnectionState];


### PR DESCRIPTION
This pull request introduces a WebSocket test utility and refactors the application to support centralized WebSocket management via context. The main goal is to make it easier to test WebSocket connections and keypoint data transmission, while also improving code structure and maintainability by using a context provider for WebSocket state and actions.

**WebSocket Testing & UI Enhancements**
* Added a new `WebSocketTestComponent` that provides a user interface for testing WebSocket connections, sending ping and keypoint messages, streaming keypoints at 10 FPS, and viewing message history and error states. This includes random keypoint generation matching MediaPipe format for pose, face, and hands. (`src/components/WebSocketTestComponent.tsx`)
* Updated the main app UI to include a "Test" button (using the `TestTube` icon) in the header, which toggles the display of the `WebSocketTestComponent`. The settings and test controls are now visually grouped and improved for usability. (`src/App.tsx`)

**WebSocket Context Refactor**
* Introduced a new `WebSocketProvider` and `useWebSocketContext` in `websocketContext.tsx` to manage WebSocket connection state, message sending, and error handling across the app. The provider wraps the main app and supplies connection utilities and state. (`src/contexts/websocketContext.tsx`)
* Refactored the main app to use the new `WebSocketProvider`, enabling centralized connection management and easier access to WebSocket state and actions. (`src/App.tsx`)

**State Management Improvements**
* Added a new state variable `showTestComponent` to `App.tsx` for toggling the test component, allowing users to switch between the main app and the WebSocket testing interface. (`src/App.tsx`) [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R28) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R159-R167)